### PR TITLE
Non-String type keys and cloning support

### DIFF
--- a/lib/attribute_struct/attribute_hash.rb
+++ b/lib/attribute_struct/attribute_hash.rb
@@ -185,7 +185,10 @@ class AttributeStruct
     # @return [Hash] The mash as a Hash with symbolized keys.
     def symbolize_keys
       h = Hash.new(default)
-      each { |key, val| h[key.to_sym] = val }
+      each do |key, val|
+        key = key.to_sym if key.is_a?(String) || key.is_a?(Symbol)
+        h[key] = val
+      end
       h
     end
 

--- a/lib/attribute_struct/attribute_struct.rb
+++ b/lib/attribute_struct/attribute_struct.rb
@@ -525,9 +525,13 @@ class AttributeStruct < BasicObject
   def _klass
     ::AttributeStruct
   end
-  alias_method :klass!, :_klass
-  alias_method :class!, :_klass
-  alias_method :class, :_klass
+
+  # @return [Class] this clas
+  def klass!
+    _klass
+  end
+  alias_method :class!, :klass!
+  alias_method :class, :klass!
 
   # @return [AttributeStruct] new struct instance
   # @note will set self as parent and propogate camelizing status
@@ -633,9 +637,33 @@ class AttributeStruct < BasicObject
     !!@_kernelified
   end
 
+  # @return [Numeric]
   def hash
     ::Kernel.instance_method(:hash).bind(self).curry.call
   end
+
+  # @return [AttributeStruct] clone of current instance
+  def _clone(_new_parent=nil)
+    _cloned_inst = _klass_new
+    _cloned_inst.__table = __hashish[
+      @table.map{ |_key, _value|
+        if(_key.is_a?(::AttributeStruct))
+          _key = _key._clone
+        else
+          _key = _do_dup(_key)
+        end
+        if(_value.is_a?(::AttributeStruct))
+          _value = _value._clone
+        else
+          _value = _do_dup(_value)
+        end
+        [_key, _value]
+      }
+    ]
+    _cloned_inst._parent(_new_parent) if _new_parent
+    _cloned_inst
+  end
+  alias_method :clone!, :_clone
 end
 
 require 'attribute_struct/attribute_hash'

--- a/test/specs/basic.rb
+++ b/test/specs/basic.rb
@@ -289,5 +289,56 @@ describe AttributeStruct do
       end
     end
 
+    describe 'instance cloning' do
+      before do
+        @struct = AttributeStruct.new do
+          fubar do
+            value1 1
+            value2 2
+            value3 do
+              value4 4
+            end
+          end
+        end
+      end
+
+      it 'should clone a new instance' do
+        cloned = @struct._clone
+        cloned.hash.wont_equal @struct.hash
+      end
+
+      it 'should not change values in original instance' do
+        cloned = @struct.fubar._clone
+        cloned.value1 10
+        inst_hash = @struct._dump
+        cloned_hash = cloned._dump
+        inst_hash.to_smash.get(:fubar, :value1).must_equal 1
+        cloned_hash.to_smash.get(:value1).must_equal 10
+      end
+
+      it 'should have the same parent' do
+        cloned = @struct.fubar._clone
+        cloned._parent.must_equal @struct._parent
+      end
+
+      it 'should have the same parent and show unchanged data' do
+        cloned = @struct.fubar._clone
+        cloned.value1 10
+        inst_hash = @struct._dump
+        cloned_hash = cloned._dump
+        inst_hash.to_smash.get(:fubar, :value1).must_equal 1
+        cloned_hash.to_smash.get(:value1).must_equal 10
+        cloned_parent_hash = cloned._parent._dump
+        cloned_parent_hash.to_smash.get(:value1).must_equal 1
+      end
+
+      it 'should allow defining a new parent' do
+        new_struct = AttributeStruct.new do
+          new_struct true
+        end
+        cloned = @struct.fubar._clone(new_struct)
+        cloned._parent._dump.to_smash.get(:new_struct).must_equal true
+      end
+    end
   end
 end

--- a/test/specs/basic.rb
+++ b/test/specs/basic.rb
@@ -263,7 +263,30 @@ describe AttributeStruct do
       it 'should contain all values' do
         @struct._dump['fubar']['feebar']['things'].keys.sort.must_equal ['ohai', 'other', 'stuff', 'testings']
       end
+    end
 
+    describe 'non-stringish keys' do
+
+      it 'should allow using AttributeStructs as keys' do
+        result = AttributeStruct.new do
+          key = fubar do
+            feebar true
+          end
+          set!(key) do
+            foobar true
+          end
+        end._dump
+        result.keys.must_include({'feebar' => true})
+      end
+
+      it 'should allow using Array as keys' do
+        result = AttributeStruct.new do
+          set!([1,2,3]) do
+            fubar true
+          end
+        end._dump
+        result.keys.must_include [1,2,3]
+      end
     end
 
   end


### PR DESCRIPTION
Adds support for using non-String type values as keys in underlying data structure. Adds cloning support for AttributeStruct instances. 